### PR TITLE
Refactor Bottom Navigation Bar label appearance

### DIFF
--- a/app/src/main/java/com/itsjeel01/finsiblefrontend/ui/view/components/BottomNavBar.kt
+++ b/app/src/main/java/com/itsjeel01/finsiblefrontend/ui/view/components/BottomNavBar.kt
@@ -34,10 +34,12 @@ fun BottomNavBar(navController: NavHostController) {
 
                 NavigationBarItem(
                     selected = isSelected,
-                    alwaysShowLabel = true,
+                    alwaysShowLabel = false,
                     label = {
-                        val labelFontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal
-                        Text(navigationItem.label, fontWeight = labelFontWeight)
+                        Text(
+                            navigationItem.label,
+                            style = MaterialTheme.typography.bodySmall.copy(fontWeight = FontWeight.SemiBold)
+                        )
                     },
                     colors = finsibleNavigationBarItemColors(),
                     icon = {


### PR DESCRIPTION
- Set `alwaysShowLabel` to `false` in `NavigationBarItem` to hide labels when unselected.
- Apply `FontWeight.SemiBold` to the `NavigationBarItem` label text using `MaterialTheme.typography.bodySmall`.