### PR TITLE
Upgrade Gradle, Kotlin, and dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.kotlin.android)
@@ -42,11 +44,13 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = "1.8"
+    kotlin {
+        compilerOptions {
+            jvmTarget = JvmTarget.JVM_17
+        }
     }
     buildFeatures {
         buildConfig = true
@@ -69,7 +73,6 @@ secrets {
 }
 
 dependencies {
-    implementation(libs.androidx.navigation.compose)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.hilt.android)
     implementation(libs.androidx.activity)
@@ -91,6 +94,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.core)
 
     ksp(libs.hilt.compiler)
+    ksp(libs.kotlin.metadata.jvm)
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     package="com.itsjeel01.finsiblefrontend">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
         android:name=".FinsibleApp"
@@ -20,8 +21,8 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:windowSoftInputMode="adjustResize"
-            android:theme="@style/Theme.FinsibleFrontend">
+            android:theme="@style/Theme.FinsibleFrontend"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,36 +1,39 @@
 [versions]
-agp = "8.13.1"
+agp = "8.13.2"
+kotlinMetadataJvm = "2.3.0"
 objectboxAndroid = "5.0.1"
 objectboxAndroidObjectbrowser = "5.0.1"
-retrofit = "2.11.0"
+retrofit = "3.0.0"
 secretsGradlePlugin = "2.0.1"
-credentials = "1.3.0"
+credentials = "1.5.0"
 hiltNavigationCompose = "1.3.0"
-kotlin = "2.1.0"
-coreKtx = "1.15.0"
+kotlin = "2.3.0"
+coreKtx = "1.17.0"
 junit = "4.13.2"
-junitVersion = "1.2.1"
-espressoCore = "3.6.1"
-mockk = "1.13.12"
-coroutinesTest = "1.9.0"
-lifecycleRuntimeKtx = "2.8.7"
-activityCompose = "1.10.0"
-securityCrypto = "1.1.0-alpha06"
-kotlinxSerializationJson = "1.7.3"
-kotlinxSerialization = "2.1.0-RC"
-hilt = "2.52"
-ksp = "2.1.0-1.0.29"
-activityKtx = "1.10.0"
+junitVersion = "1.3.0"
+espressoCore = "3.7.0"
+mockk = "1.14.7"
+coroutinesTest = "1.10.2"
+lifecycleRuntimeKtx = "2.10.0"
+activityCompose = "1.12.2"
+securityCrypto = "1.1.0"
+kotlinxSerializationJson = "1.9.0"
+kotlinxSerialization = "2.3.0"
+hilt = "2.57.2"
+ksp = "2.3.3"
+activityKtx = "1.12.2"
 googleid = "1.1.1"
-objectBox = "4.3.1"
+objectBox = "5.0.1"
 material3 = "1.4.0"
 timber = "5.0.1"
-okHttpLoggingInterceptor = "4.12.0"
+okHttpLoggingInterceptor = "5.3.2"
 nav3Core = "1.0.0"
 lifecycleViewmodelNav3 = "2.10.0"
-kotlinxSerializationCore = "1.8.1"
+kotlinxSerializationCore = "1.9.0"
 material3AdaptiveNav3 = "1.3.0-alpha05"
-animation = "1.10.0"
+composeBom = "2025.12.01"
+composeUi = "1.10.0"
+coreTesting = "2.2.0"
 
 [libraries]
 androidx-activity = { module = "androidx.activity:activity", version.ref = "activityCompose" }
@@ -43,13 +46,14 @@ converter-kotlinx-serialization = { module = "com.squareup.retrofit2:converter-k
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
+kotlin-metadata-jvm = { module = "org.jetbrains.kotlin:kotlin-metadata-jvm", version.ref = "kotlinMetadataJvm" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutinesTest" }
-androidx-core-testing = { group = "androidx.arch.core", name = "core-testing", version = "2.2.0" }
+androidx-core-testing = { group = "androidx.arch.core", name = "core-testing", version.ref = "coreTesting" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
-androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version = "2025.01.00" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
@@ -57,11 +61,10 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
-androidx-ui-text-google-fonts = { group = "androidx.compose.ui", name = "ui-text-google-fonts", version = "1.7.6" }
-androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version = "2.8.5" }
+androidx-ui-text-google-fonts = { group = "androidx.compose.ui", name = "ui-text-google-fonts", version.ref = "composeUi" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
-hilt-android = { group = "com.google.dagger", name = "hilt-android", version = "2.53.1" }
-hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version = "2.53.1" }
+hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
+hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
 activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "activityKtx" }
 googleid = { group = "com.google.android.libraries.identity.googleid", name = "googleid", version.ref = "googleid" }
 objectbox-android = { module = "io.objectbox:objectbox-android", version.ref = "objectboxAndroid" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Nov 30 15:19:14 IST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This commit upgrades the project's build tools and dependencies.

Key changes include:
- Upgraded Gradle from 8.14.3 to 9.2.1.
- Bumped Kotlin version to 2.3.0 and set JVM target to 17.
- Updated various libraries including AGP, Hilt, Retrofit, ObjectBox, and Coroutines.
- Added `kotlin-metadata-jvm` dependency.
- Added `ACCESS_NETWORK_STATE` permission in `AndroidManifest.xml`.